### PR TITLE
Fix sub-path deployment by preserving mount prefix in URLs

### DIFF
--- a/Backend/backend/backend/settings.py
+++ b/Backend/backend/backend/settings.py
@@ -102,6 +102,13 @@ AUTH_COOKIE_SECURE = not DEBUG
 AUTH_COOKIE_MAX_AGE = TOKEN_TTL_HOURS * 3600
 AUTH_COOKIE_PATH = env("AUTH_COOKIE_PATH", default="/")
 
+# The tool is served under a sub-path (APP_BASE_PATH, e.g. "/sysadmin/") behind an
+# nginx that strips the prefix before proxying. FORCE_SCRIPT_NAME makes Django
+# re-add it to every generated URL — APPEND_SLASH redirects, reverse(), and DRF
+# pagination/browsable-API links — so they don't drop the mount path and fall
+# through to the main app. Resolution still uses the stripped path nginx sends.
+FORCE_SCRIPT_NAME = env("APP_BASE_PATH", default="/").rstrip("/") or None
+
 # Optional at-rest encryption for backup dump files (a Fernet key). When set, dumps
 # are encrypted on disk and decrypted transparently on restore; when empty, dumps are
 # stored as plain pg_dump output (unchanged behaviour). Generate one with:

--- a/client/src/api/Users.jsx
+++ b/client/src/api/Users.jsx
@@ -82,7 +82,7 @@ export const bulkUploadUsers = async (userData) => {
 
 export const downloadSampleCSV = async () => {
   try {
-    const response = await axiosInstance.get("/download-sample-csv", {
+    const response = await axiosInstance.get("/download-sample-csv/", {
       responseType: "blob",
     });
 
@@ -106,7 +106,7 @@ export const downloadSampleCSV = async () => {
 
 export const fetchUsersByType = async (type) => {
   try {
-    const response = await axiosInstance.get("/users", {
+    const response = await axiosInstance.get("/users/", {
       params: { type },
     });
     return response.data;


### PR DESCRIPTION
- settings: add FORCE_SCRIPT_NAME derived from APP_BASE_PATH so Django re-adds the sub-path (e.g. /sysadmin) to every generated URL -- APPEND_SLASH redirects, reverse(), and DRF pagination / browsable-API links -- since nginx strips the prefix before proxying. Without it, a no-slash call like /users redirected (301) to /api/users/ and fell through to the main Fusion app (404).
- client: use trailing slashes on the users and sample-csv endpoints so they don't trigger that prefix-dropping redirect in the first place.