### PR TITLE
fix: defer section field to handle database schema mismatch

### DIFF
--- a/Backend/backend/api/services/batches.py
+++ b/Backend/backend/api/services/batches.py
@@ -519,7 +519,7 @@ def batch_students(batch_id, specialization=None):
         raise ServiceError({"success": False, "message": f"Batch with ID {batch_id} not found"}, status=404)
 
     programme_type = "ug" if batch.name.startswith("B.") else "pg" if batch.name.startswith("M.") else "phd"
-    students = StudentBatchUpload.objects.filter(year=batch.year, programme_type=programme_type)
+    students = StudentBatchUpload.objects.filter(year=batch.year, programme_type=programme_type).defer("section")
 
     discipline = batch.discipline
     if programme_type == "pg" and specialization:


### PR DESCRIPTION
## Problem
- Database column `programme_curriculum_studentbatchupload.section` does not exist in production DB
- Causes 500 error when fetching batch students

## Root Cause
- StudentBatchUpload model defines a `section` field
- But production database schema doesn't have this column
- Django ORM tries to load all fields, including non-existent ones

## Solution
- Use `.defer("section")` when querying StudentBatchUpload
- Skips loading the missing column from database
- Allows API to work with schema mismatches

## Testing
- Tested on batch ID 103
- Now returns student data instead of 500 error

## Related
- Builds on PR #87 (defensive serialization fix)
- Part of batch_students 500 error resolution